### PR TITLE
feat: add direction support for right and down

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ The tag follows this format: `[operation][direction][start:end][currency]`
 	* `MAX`: Finds the maximum value.
 	* `SUB`: Subtracts the subsequent values from the first value.
 	* `MUL`: Multiplies all the values together.
+	* `DIV`: Divides the first value by each subsequent value in sequence.
 * **`[direction]`**: Indicates the direction of the values to operate on:
 	* `^`: Looks at the cells above the current cell in the same column.
 	* `<`: Looks at the cells to the left of the current cell in the same row.
+	* `v`: Looks at the cells below the current cell in the same column.
+	* `>`: Looks at the cells to the right of the current cell in the same row.
 * **`[start:end]`** (Optional): Specifies a range of cells to include in the calculation.
 	* If omitted, it defaults to all applicable cells in the specified direction.
 	* Use a colon-separated format (e.g., `1:3` for the first three cells). The indices are 1-based.
@@ -66,7 +69,7 @@ The tag follows this format: `[operation][direction][start:end][currency]`
 ## Key Features
 
 * **Real-time Updates:** Calculations are performed automatically as you type and edit your tables.
-* **Directional Operations:** Calculate based on values above or to the left of the tag.
+* **Directional Operations:** Calculate based on values relative to the tag.
 * **Optional Range Selection:** Target specific cells for your calculations.
 * **Currency Formatting:** Display results with currency symbols for better readability.
 * **Locale-Aware Formatting:** Respects your system's locale for number formatting by default, with an option to override.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "simple-table-math",
 	"name": "Simple Table Math",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"minAppVersion": "1.8.9",
 	"description": "Do some math (sum, average, etc.) in your markdown tables.",
 	"author": "Sandro Ducceschi",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "simple-table-math",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "simple-table-math",
-			"version": "0.2.3",
+			"version": "0.2.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/lodash": "^4.17.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "simple-table-math",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"description": "Do some math (sum, average, etc.) in your markdown tables for Obsidian (https://obsidian.md).",
 	"main": "src/main.js",
 	"scripts": {


### PR DESCRIPTION
Thanks for putting this together, this is the lightweight functionality I was looking for!  
For some of my 'live' tables (i.e. continuously appended to) having a calculated expression remain at the top and/or left hand side fits better. 
This pr adds the two remaining directions to enable that behavior. 

---

Raw table:
```
| a    | b    | c    | d    | e   |
| ---- | ---- | ---- | ---- | --- |
|      | 123  | SUMv |      |     |
| SUM> | 456  | 123  |      |     |
|      | SUM^ | 456  | SUM< |     |
| SUM> | 234  | SUM> | 789  | 456 |
|      | SUM^ | 789  |      |     |
```

Live preview:
<img width="381" height="197" alt="image" src="https://github.com/user-attachments/assets/99b1a866-e951-4e56-859e-8bbd5b59449c" />

---

**Note**: I haven't exhaustively tested the other operation types or optional args, only what's pictured here. 