### PR TITLE
Added support for scientific notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The tag follows this format: `[operation][direction][start:end][currency]`
 	* Use a colon-separated format (e.g., `1:3` for the first three cells). The indices are 1-based.
 	* You can also just specify a start (e.g., `2`).
 * **`[currency]`** (Optional): A 2-4 letter currency code (e.g., `USD`, `EUR`, `GBP`). If provided, the result will be formatted with the specified currency symbol.
+* **`[format]`** (Optional): Format options for input and output.
+	* #e[n] Only accepts inputs written in scientific notations, and outputs results in scientific notation with n fraction digits. 
 
 ## Examples
 
@@ -63,6 +65,20 @@ The tag follows this format: `[operation][direction][start:end][currency]`
 | **TOTAL:**  |        |          | SUM^2:4USD |
 ```
 
+**Scientific notation example:**
+
+Note: when using #e[n] format the input values must be in scientific notation and cannot include currency units.
+```
+| Correct | Incorrect |
+| ------: | --------: |
+|    1000 |     1,000 |
+|    -1.0 |      -1,0 |
+|   2.0e1 |       $20 |
+|     0.1 |       0,1 |
+|    1E-1 |      10 % |
+| SUM^#e4 |   SUM^#e4 |
+```
+The correct column will ouput 1.0192e+3 while the incorrect column will output 0.0000e+0.
 ## Key Features
 
 * **Real-time Updates:** Calculations are performed automatically as you type and edit your tables.

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,13 +123,16 @@ export default class SimpleTableMath extends Plugin {
 				...(this.settings.styleLastRow ? [] :  ['off']),
 			];
 
+			const defaultNumRegex = /-?\d+(?:[.,'’`\u202f]\d{3})*(?:[.,]\d+)?/;
+			const exponentialRegex = /^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$/;
+						
 			tables.forEach((table) => {
 				const rows = Array.from(table.querySelectorAll('tr'));
 				rows.forEach((row, rowIndex) => {
 					const cells = Array.from(row.children) as HTMLTableCellElement[];
 					cells.forEach((cell, colIndex) => {
 						const rawText = this.extractCellContent(cell).trim().toLowerCase() || '';
-						const match = rawText.match(/^([a-z]{3})([<^])(?:(\d+)(?::(\d+))?)?([a-z]{2,4})?$/i);
+						const match = rawText.match(/^([a-z]{3})([<^])(?:(\d+)(?::(\d+))?)?([a-z]{2,4})?(?:\#e(\d+))?$/i);
 						const isActiveElement = this.isDocumentActiveElementChildOf(cell)
 						if (match && !isActiveElement) {
 							const operation = match[1].toLowerCase();
@@ -137,6 +140,8 @@ export default class SimpleTableMath extends Plugin {
 							const startStr = match[3];
 							const endStr = match[4];
 							const currency = match[5]?.toUpperCase() || null;
+							const exponential = match[6] ? parseInt(match[6], 10) : 0;
+							const numRegex = exponential ? exponentialRegex : defaultNumRegex;
 							const values: number[] = [];
 
 							let startIndex = startStr ? parseInt(startStr, 10) - 1 : 0;
@@ -157,7 +162,7 @@ export default class SimpleTableMath extends Plugin {
 									for (let r = actualStartRow; r <= finalEndRow; r++) {
 										const aboveCell = rows[r]?.children?.[colIndex] as HTMLTableCellElement | undefined | null;
 										const textContent = this.extractCellContent(aboveCell, true);
-										const value = this.extractNumber(textContent);
+										const value = this.extractNumber(textContent, numRegex);
 										if (value !== null) {
 											values.push(value);
 										}
@@ -171,7 +176,7 @@ export default class SimpleTableMath extends Plugin {
 									for (let c = actualStartCol; c <= finalEndCol; c++) {
 										const leftCell = cells[c] as HTMLTableCellElement | undefined | null;
 										const textContent = this.extractCellContent(leftCell, true);
-										const value = this.extractNumber(textContent);
+										const value = this.extractNumber(textContent, numRegex);
 										if (value !== null) {
 											values.push(value);
 										}
@@ -218,12 +223,16 @@ export default class SimpleTableMath extends Plugin {
 									cell.tabIndex = -1;
 									cell.closest('tr')?.classList.add(...rowClasses);
 									const defaultLocale = getLanguage();
-									vElement.textContent = result.toLocaleString(this.settings.locale || defaultLocale, {
-										style: currency ? 'currency' : 'decimal',
-										currency: currency || undefined,
-										minimumFractionDigits: this.settings.fractions,
-										maximumFractionDigits: this.settings.fractions,
-									});
+									if (exponential) {
+										vElement.textContent = result.toExponential(exponential)
+									} else {
+										vElement.textContent = result.toLocaleString(this.settings.locale || defaultLocale, {
+											style: currency ? 'currency' : 'decimal',
+											currency: currency || undefined,
+											minimumFractionDigits: this.settings.fractions,
+											maximumFractionDigits: this.settings.fractions,
+										})
+									}; 
 								}
 							}
 						} else if (!isActiveElement && cell.classList.contains('stm-cell')) {
@@ -332,12 +341,11 @@ export default class SimpleTableMath extends Plugin {
 		return wrapper?.textContent || '';
 	}
 
-	extractNumber(str: string | null): number | null{
+	extractNumber(str: string | null, numRegex: RegExp): number | null{
 		if (!str) {
 			return null;
 		}
-
-		const match = str.match(/-?\d+(?:[.,'’`\u202f]\d{3})*(?:[.,]\d+)?/);
+		const match = str.match(numRegex);
 		if (!match) {
 			return null;
 		}


### PR DESCRIPTION
by adding #e[n] to the end of a calculation tag, the calculation will now interpret the inputs in exponential format and will output the result as an exponential with n fractionDigits.
Although it might be better to separate input format requirements, and results formatting options.