### PR TITLE
Add setting to skip header row in calculations

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,12 +22,14 @@ interface SimpleTableMathSettings {
 	fractions: number;
 	locale: string | null;
 	styleLastRow: boolean;
+	skipHeaderRow: boolean;
 }
 
 const DEFAULT_SETTINGS: SimpleTableMathSettings = {
 	fractions: 2,
 	locale: null,
 	styleLastRow: true,
+	skipHeaderRow: false,
 }
 
 /**
@@ -156,7 +158,8 @@ export default class SimpleTableMath extends Plugin {
 							}
 
 							if (direction === '^') {
-								const actualStartRow = Math.max(0, startIndex);
+								const minStartRow = this.settings.skipHeaderRow ? 1 : 0;
+								const actualStartRow = Math.max(minStartRow, startIndex);
 								const actualEndRow = endIndex !== -1 ? endIndex : rowIndex - 1;
 								const finalEndRow = Math.min(actualEndRow, rowIndex - 1);
 								if (actualStartRow <= finalEndRow) {
@@ -420,6 +423,16 @@ class SettingTab extends PluginSettingTab {
 				.setValue(this.plugin.settings.styleLastRow)
 				.onChange(async (value) => {
 					this.plugin.settings.styleLastRow = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
+			.setName('Skip header row')
+			.setDesc('When enabled, the first row of each table will be excluded from vertical (^) calculations. Useful when your header row contains numbers.')
+			.addToggle(component => component
+				.setValue(this.plugin.settings.skipHeaderRow)
+				.onChange(async (value) => {
+					this.plugin.settings.skipHeaderRow = value;
 					await this.plugin.saveSettings();
 				}));
 	}


### PR DESCRIPTION
## Summary
- Adds a new "Skip header row" toggle in settings
- When enabled, the first row of each table is excluded from vertical (^) calculations
- Useful when header rows contain numbers that shouldn't be included in sums, averages, etc.

## Problem
When table headers contain numbers (e.g., "Q1 2024", "Item #", or numeric column labels), these get included in vertical calculations like `sum^` or `avg^`, producing incorrect results.

## Solution
A simple toggle that, when enabled, starts vertical calculations from row index 1 instead of 0, effectively skipping the header row.

## Test plan
- [ ] Enable "Skip header row" in settings
- [ ] Create a table with numbers in the header row
- [ ] Verify that `sum^`, `avg^`, etc. exclude the header values
- [ ] Disable the setting and confirm headers are included again

🤖 Generated with [Claude Code](https://claude.ai/claude-code)